### PR TITLE
remove binary zeros from strings

### DIFF
--- a/src/main/java/pz/tool/jdbcimage/db/BinaryZerosRemover.java
+++ b/src/main/java/pz/tool/jdbcimage/db/BinaryZerosRemover.java
@@ -1,0 +1,9 @@
+package pz.tool.jdbcimage.db;
+
+public class BinaryZerosRemover {
+    public String removeBinaryZeros(String input) {
+        if (input == null) return null;
+
+        return input.replace("\u0000", "");
+    }
+}

--- a/src/main/java/pz/tool/jdbcimage/db/DbImportResultConsumer.java
+++ b/src/main/java/pz/tool/jdbcimage/db/DbImportResultConsumer.java
@@ -22,6 +22,7 @@ public class DbImportResultConsumer implements ResultConsumer<RowData>{
     private Connection con;
     private DBFacade db;
     private Map<String,String> actualColumns;
+    private BinaryZerosRemover binaryZerosRemover = new BinaryZerosRemover();
 
     // initialize in on start
     private PreparedStatement stmt = null;
@@ -118,11 +119,11 @@ public class DbImportResultConsumer implements ResultConsumer<RowData>{
                                 break;
                             case Types.CHAR:
                             case Types.VARCHAR:
-                                stmt.setString(pos, (String)value);
+                                stmt.setString(pos, binaryZerosRemover.removeBinaryZeros((String)value));
                                 break;
                             case Types.NCHAR:
                             case Types.NVARCHAR:
-                                stmt.setNString(pos, (String)value);
+                                stmt.setNString(pos, binaryZerosRemover.removeBinaryZeros((String)value));
                                 break;
                             case Types.DATE:
                                 stmt.setDate(pos, (Date)value);
@@ -179,7 +180,7 @@ public class DbImportResultConsumer implements ResultConsumer<RowData>{
                                     } else if (value instanceof Reader ){
                                         stmt.setCharacterStream(pos, (Reader)value);
                                     } else if (value instanceof CharSequence){
-                                        stmt.setString(pos, value.toString());
+                                        stmt.setString(pos, binaryZerosRemover.removeBinaryZeros(value.toString()));
                                     } else{
                                         throw new IllegalStateException("Unexpected value found for clob: "+value);
                                     }

--- a/src/main/java/pz/tool/jdbcimage/db/DbImportResultConsumer.java
+++ b/src/main/java/pz/tool/jdbcimage/db/DbImportResultConsumer.java
@@ -117,6 +117,7 @@ public class DbImportResultConsumer implements ResultConsumer<RowData>{
                             case Types.BIT:
                                 stmt.setBoolean(pos, (Boolean)value);
                                 break;
+                            case Types.OTHER:
                             case Types.CHAR:
                             case Types.VARCHAR:
                                 stmt.setString(pos, binaryZerosRemover.removeBinaryZeros((String)value));

--- a/src/main/java/pz/tool/jdbcimage/kryo/KryoResultProducer.java
+++ b/src/main/java/pz/tool/jdbcimage/kryo/KryoResultProducer.java
@@ -65,6 +65,7 @@ public class KryoResultProducer implements ResultProducer{
 				case Types.BIT:
 					val = kryo.readObjectOrNull(in, Boolean.class);
 					break;
+                case Types.OTHER:
 				case Types.CHAR:
 				case Types.NCHAR:
 				case Types.VARCHAR:

--- a/src/main/java/pz/tool/jdbcimage/kryo/KryoResultSetConsumer.java
+++ b/src/main/java/pz/tool/jdbcimage/kryo/KryoResultSetConsumer.java
@@ -60,6 +60,7 @@ public class KryoResultSetConsumer implements ResultConsumer<ResultSet>{
 						if (rs.wasNull()) bVal = null;
 						kryo.writeObjectOrNull(out, bVal, Boolean.class);
 						break;
+                    case Types.OTHER:
 					case Types.CHAR:
 					case Types.VARCHAR:
 						kryo.writeObjectOrNull(out, rs.getString(i+1), String.class);

--- a/src/test/java/pz/tool/jdbcimage/db/BinaryZerosRemoverTest.java
+++ b/src/test/java/pz/tool/jdbcimage/db/BinaryZerosRemoverTest.java
@@ -1,0 +1,22 @@
+package pz.tool.jdbcimage.db;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BinaryZerosRemoverTest {
+
+    @Test
+    public void shouldRemoveAllBinaryZerosFromString() {
+        BinaryZerosRemover bzr = new BinaryZerosRemover();
+
+        assertEquals("abcdefghijkl", bzr.removeBinaryZeros("\0abc\0def\0ghi\u0000jkl"));
+    }
+
+    @Test
+    public void shouldNotFailOnNulls() {
+        BinaryZerosRemover bzr = new BinaryZerosRemover();
+
+        assertNull(bzr.removeBinaryZeros(null));
+    }
+}


### PR DESCRIPTION
In MySQL/MariaDB it can happen that strings are stored with binary 0 inside of the strings. When moving MySQL/MariaDB to Postgres and when there are such strings in the source DB, Postgres will fail to insert such records with org.postgresql.util.PSQLException: ERROR: invalid byte sequence for encoding "UTF8": 0x00.

It sounds like a good idea, to remove binary zeros from the db image on import.