### PR TITLE
SQL Server insert into identity column fails due to case insensitivity

### DIFF
--- a/src/main/java/io/github/sranka/jdbcimage/main/Mssql.java
+++ b/src/main/java/io/github/sranka/jdbcimage/main/Mssql.java
@@ -110,6 +110,7 @@ public class Mssql extends DBFacade {
             Set<String> schemaColumns = tableInfo.getTableColumns().keySet();
             Set<String> importedColumns = Arrays.stream(fileInfo.columns)
                     .filter(col -> schemaColumns.contains(col.toLowerCase()))
+                    .map(String::toLowerCase)
                     .collect(Collectors.toSet());
             return identityColumns.stream().anyMatch(importedColumns::contains);
         }


### PR DESCRIPTION
This pull request will fix the issue: https://github.com/sranka/jdbcimage/issues/21

SQL Server insert into identity column fails due to case insensitivity · Issue #21 · sranka/jdbcimage
